### PR TITLE
SXT clears the V flag

### DIFF
--- a/op00.py
+++ b/op00.py
@@ -304,6 +304,7 @@ def op00_67_sxt(cpu, inst):
     else:
         val = 0
     cpu.psw_z = not cpu.psw_n
+    cpu.psw_v = 0
     cpu.operandx(inst & 0o0077, val)
 
 


### PR DESCRIPTION
Source: https://bitsavers.org/pdf/dec/pdp11/1170/PDP-11_70_Handbook_1977-78.pdf page 60 (4-20)