### PR TITLE
SWAP & N flag

### DIFF
--- a/op000.py
+++ b/op000.py
@@ -83,7 +83,7 @@ def op_swab(cpu, inst):
     val, xb6 = cpu.operandx(inst & 0o77, rmw=True)
 
     val = ((val >> 8) & cpu.MASK8) | ((val & cpu.MASK8) << 8)
-    cpu.psw_n = val & cpu.SIGN16
+    cpu.psw_n = val & cpu.SIGN8
 
     # note this screwy definition, per the handbook
     cpu.psw_z = ((val & cpu.MASK8) == 0)


### PR DESCRIPTION
According to https://bitsavers.org/pdf/dec/pdp11/1170/PDP-11_70_Handbook_1977-78.pdf page 64 (4-24):

"N: set if high-order bit of low-order byte (bit 7) of result is set; cleared otherwise"