### PR TITLE
Misc

### DIFF
--- a/mmio.py
+++ b/mmio.py
@@ -157,7 +157,7 @@ class MMIO:
         self.device_resets = set()
 
     # the default entry for unoccupied I/O: cause an AddressError trap
-    def __nodev(self, addr, value=None, /):
+    def __nodev(self, addr, value=None, opsize=1):
         self.cpu.logger.info(f"Access to non-existent I/O {oct(addr)}")
         raise PDPTraps.AddressError(
             cpuerr=self.cpu.CPUERR_BITS.UNIBUS_TIMEOUT)

--- a/op07.py
+++ b/op07.py
@@ -154,7 +154,7 @@ def _shifter(cpu, value, shift, *, opsize):
         cpu.psw_n = vsign
         cpu.psw_z = (value == 0)
         cpu.psw_v = 0
-        # C is not altered
+        cpu.psw_c = 0
         return value
     elif shift > 31:       # right shift
         # sign extend if appropriate, so the sign propagates

--- a/op07.py
+++ b/op07.py
@@ -34,6 +34,8 @@
 # op076 is the commercial instruction set
 #
 
+from pdptraps import PDPTraps
+
 
 def op070_mul(cpu, inst):
     dstreg = (inst & 0o000700) >> 6


### PR DESCRIPTION
Open for discussion regarding the carry-flag clear when shift of 0 positions is performed.
3 out of emulators I checked (including simh) clear the C flag. Otoh leaving it as-is makes more sense. What is wisdom?