### PR TITLE
NEG

### DIFF
--- a/op00.py
+++ b/op00.py
@@ -122,7 +122,7 @@ def op00_54_neg(cpu, inst, opsize=2):
 
     cpu.psw_n = newval & cpu.SIGN816[opsize]
     cpu.psw_z = (newval == 0)
-    cpu.psw_v = (val == newval)    # happens at the maximum negative value
+    cpu.psw_v = 1 if (val == 0o200 and opsize == 1) or (val == 0o100000 and opsize == 2) else 0
     cpu.psw_c = (newval != 0)
 
     cpu.operandx(xb6, newval, opsize=opsize)


### PR DESCRIPTION
According to http://www.bitsavers.org/pdf/dec/pdp11/handbooks/EB-24944-18_Micro_PDP-11_Handbook_1983-84.pdf page 319, V is also set when doing a NEGB with a value of 0200.
Now checking if val == newval works for that case but fails for val being 0.